### PR TITLE
Invalidate all paths in cy7.io Cloudfront distribution on deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,11 +62,23 @@ jobs:
         with:
           terraform_version: 0.14.7
       - run: terraform fmt -check deploy/infra
+  query-existing-infrastructure:
+    runs-on: ubuntu-20.04
+    outputs:
+      website-cloudfront-distribution-id: ${{ steps.read-website-cloudfront-distribution-id.id }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 0.14.7
+      - id: read-website-cloudfront-distribution-id
+        run: echo "::set-output name=id:$(terraform output -json | jq -r '.website_cloudfront_distribution_id.value')"
   deploy:
     needs:
       - build
       - check-frontend-code-quality
       - check-terraform-code-quality
+      - query-existing-infrastructure
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -80,7 +92,9 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-east-1
-      - run: aws s3 sync public s3://cy7.io
+      - run: |
+          aws s3 sync public s3://cy7.io
+          aws cloudfront create-invalidation --distribution-id ${{ needs.query-existing-infrastructure.outputs.website-cloudfront-distribution-id }} --paths "/*"
   deploy-storybook:
     needs:
       - build-storybook

--- a/deploy/infra/modules/static_site/outputs.tf
+++ b/deploy/infra/modules/static_site/outputs.tf
@@ -1,3 +1,7 @@
+output "cloudfront_distribution_id" {
+  value = aws_cloudfront_distribution.web.id
+}
+
 output "cloudfront_domain" {
   value = aws_cloudfront_distribution.web.domain_name
 }

--- a/deploy/infra/outputs.tf
+++ b/deploy/infra/outputs.tf
@@ -1,0 +1,7 @@
+output "website_cloudfront_distribution_id" {
+  value = module.website.cloudfront_distribution_id
+}
+
+output "storybook_cloudfront_distribution_id" {
+  value = module.storybook.cloudfront_distribution_id
+}


### PR DESCRIPTION
Since default TTL config tends to result in pages being cached for 24 hours, it's worth invalidating Cloudfront's cache after a deploy, so that new content reaches users sooner.

I'm just going with invalidating every possible cached path as a first solution. More granular cache invalidations would be a good future improvement, since not every deploy will affect every page. But this is cheap + easy to understand while the website still contains few pages. Plus, since there's near-zero traffic, cache misses will be common no matter what anyway...

## Notes

To expand on the above a bit more... "too many cache invalidations" won't be a performance bottleneck as things stand. 

A bigger issue is that cache misses result in ~500ms response times (vs more like <50ms for cache hits). Although misses are obviously expected to be slower than hits, I don't think the difference should be as severe 🤔 needs more investigation.