### PR TITLE
Fix Terraform workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,6 +64,11 @@ jobs:
       - uses: hashicorp/setup-terraform@v1
         with:
           terraform_version: 1.1.9
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
       - run: terraform fmt -check
       - run: terraform init
       - run: terraform validate

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,12 +56,15 @@ jobs:
       - run: LEFTHOOK_EXCLUDE=infra yarn lefthook run check-all
   check-terraform-code-quality:
     runs-on: ubuntu-20.04
+    defaults:
+      run:
+        working-directory: deploy/infra
     steps:
       - uses: actions/checkout@v2
       - uses: hashicorp/setup-terraform@v1
         with:
           terraform_version: 1.1.9
-      - run: terraform fmt -check deploy/infra
+      - run: terraform fmt -check
       - run: terraform init
       - run: terraform validate
   query-existing-infrastructure:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,8 +60,10 @@ jobs:
       - uses: actions/checkout@v2
       - uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 0.14.7
+          terraform_version: 1.1.9
       - run: terraform fmt -check deploy/infra
+      - run: terraform init
+      - run: terraform validate
   query-existing-infrastructure:
     runs-on: ubuntu-20.04
     outputs:
@@ -73,7 +75,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 0.14.7
+          terraform_version: 1.1.9
       - uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/validate-pushed-code.yml
+++ b/.github/workflows/validate-pushed-code.yml
@@ -46,11 +46,14 @@ jobs:
       - run: LEFTHOOK_EXCLUDE=infra yarn lefthook run check-all
   check-terraform-code-quality:
     runs-on: ubuntu-20.04
+    defaults:
+      run:
+        working-directory: deploy/infra
     steps:
       - uses: actions/checkout@v2
       - uses: hashicorp/setup-terraform@v1
         with:
           terraform_version: 1.1.9
-      - run: terraform fmt -check deploy/infra
+      - run: terraform fmt -check
       - run: terraform init
       - run: terraform validate

--- a/.github/workflows/validate-pushed-code.yml
+++ b/.github/workflows/validate-pushed-code.yml
@@ -50,5 +50,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 0.14.7
+          terraform_version: 1.1.9
       - run: terraform fmt -check deploy/infra
+      - run: terraform init
+      - run: terraform validate

--- a/.github/workflows/validate-pushed-code.yml
+++ b/.github/workflows/validate-pushed-code.yml
@@ -54,6 +54,11 @@ jobs:
       - uses: hashicorp/setup-terraform@v1
         with:
           terraform_version: 1.1.9
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
       - run: terraform fmt -check
       - run: terraform init
       - run: terraform validate

--- a/deploy/infra/main.tf
+++ b/deploy/infra/main.tf
@@ -23,6 +23,15 @@ locals {
   root_domain = "cy7.io"
 }
 
+data "aws_cloudformation_export" "subdirectory_index_lambda_arn" {
+  name = "cy7-subdirectory-index-lambda-arn"
+}
+
+data "aws_cloudformation_export" "redirect_lambda_arn" {
+  name = "cy7-redirect-lambda-arn"
+}
+
+
 module "website" {
   source = "./modules/static_site"
 
@@ -30,11 +39,11 @@ module "website" {
   edge_lambdas = [
     {
       event_type = "viewer-request"
-      lambda_arn = jsondecode(file("${path.root}/../lambda/outputs.json")).RedirectLambdaFunctionQualifiedArn
+      lambda_arn = data.aws_cloudformation_export.redirect_lambda_arn.value
     },
     {
       event_type = "origin-request"
-      lambda_arn = jsondecode(file("${path.root}/../lambda/outputs.json")).SubdirectoryIndexLambdaFunctionQualifiedArn
+      lambda_arn = data.aws_cloudformation_export.subdirectory_index_lambda_arn.value
     }
   ]
   full_domain = "cy7.io"

--- a/deploy/lambda/README.md
+++ b/deploy/lambda/README.md
@@ -6,8 +6,11 @@ Check `handlers.js` for the logic itself. Run `yarn sls deploy` to deploy update
 
 ## Integration with Terraform
 
-The Cloudfront distribution is provisioned in Terraform. So typically you'd first deploy the updated lambda functions, then run `terraform apply` (from the `deploy/infra` directory of this repo).
+The CloudFront distribution for [cy7.io](https://cy7.io) is provisioned in Terraform. That CloudFront distribution references the Lambda@Edge functions created by this project by ARN.
 
-Terraform can read info about the deployed Lambda functions (such as their ARNs) via the `outputs.json` file generated during `sls deploy` by the [`serverless-stack-output`](https://www.serverless.com/plugins/serverless-stack-output) plugin.
+That means deployment of changes to the Lambda@Edge functions must happen in two steps:
 
-(To read `outputs.json`, you can string together Terraform's [`jsondecode`](https://www.terraform.io/docs/configuration/functions/jsondecode.html) and [`file`](https://www.terraform.io/docs/configuration/functions/file.html) functions!)
+1. Deploy the updated Lambda functions via `yarn sls deploy`.
+1. Run `terraform apply` (from the `deploy/infra` directory of this repo).
+
+> 💡 **How it works:** the CloudFormation stack created by Serverless Framework exposes the qualified Lambda ARNs via **CloudFormation Exports**. The Terraform config reads these via the [`aws_cloudformation_export`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudformation_export) data provider.

--- a/deploy/lambda/package.json
+++ b/deploy/lambda/package.json
@@ -4,8 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "serverless": "1.54.0",
-    "serverless-stack-output": "0.2.3"
+    "serverless": "1.54.0"
   },
   "engines": {
     "node": "14.16.0",

--- a/deploy/lambda/serverless.yml
+++ b/deploy/lambda/serverless.yml
@@ -16,13 +16,6 @@ package:
     - node_modules/**
     - yarn.lock
 
-plugins:
-  - serverless-stack-output
-
-custom:
-  output:
-    file: outputs.json
-
 functions:
   redirect:
     handler: handlers.redirect
@@ -41,3 +34,10 @@ resources:
                 Service:
                   - lambda.amazonaws.com
                   - edgelambda.amazonaws.com
+  Outputs:
+    SubdirectoryIndexLambdaFunctionQualifiedArn:
+      Export:
+        Name: "cy7-subdirectory-index-lambda-arn"
+    RedirectLambdaFunctionQualifiedArn:
+      Export:
+        Name: "cy7-redirect-lambda-arn"

--- a/deploy/lambda/yarn.lock
+++ b/deploy/lambda/yarn.lock
@@ -2973,14 +2973,6 @@ semver@^6.1.1, semver@^6.2.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-serverless-stack-output@0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/serverless-stack-output/-/serverless-stack-output-0.2.3.tgz#9125e61d5ac77118acb2c79849d7521913d26d96"
-  integrity sha512-bJUUXJ+bc0E+IBlWz+FyUpdNjEmSM0dYd2UpDX0h2zeW+luPOJeP//rbIamBmteJjbed9S3FtRWnLLRAJbzM5g==
-  dependencies:
-    tomlify-j0.4 "^2.0.0"
-    yamljs "^0.3.0"
-
 serverless@1.54.0:
   version "1.54.0"
   resolved "https://registry.yarnpkg.com/serverless/-/serverless-1.54.0.tgz#f7518d49887bfc3d5b7fcd634b6de44ea8c305f7"
@@ -3414,11 +3406,6 @@ to-regex@^3.0.1:
     extend-shallow "^3.0.2"
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
-
-tomlify-j0.4@^2.0.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/tomlify-j0.4/-/tomlify-j0.4-2.2.1.tgz#60c4e7dd2066b2e917dd9a0de5fd676c0a6d7c7b"
-  integrity sha512-0kCocYX8ujnbK6jQ9e+g9GLiCIfVkFaCB3DCTQDP7J79gPVZVmZgQZ/KUNe1a6hUfrmHHaErVGUjedfpaX5EZw==
 
 tr46@~0.0.3:
   version "0.0.3"


### PR DESCRIPTION
The Terraform-related Github Actions in this repo broke after upgrading to Terraform v1.1: https://github.com/cycleseven/cy7.io/pull/5. This was due to a version mismatch.

**Changes:**

- Bump Terraform version used in Github workflows to `v1.1.9` to match version used for latest infra deployment.
- Run `terraform validate` in all post-push checks to prevent an error like this from slipping through the net in future, as well as to prevent invalid config from being merged.
- Refactor shared state between Serverless Framework and Terraform to work via CloudFormation Exports rather than a local JSON file. This allows `terraform validate` to run properly in Github Actions, ie. without depending on a prior run of `yarn sls deploy`.