### PR TITLE
Replicate origin buckets to eu-west-1

### DIFF
--- a/.github/workflows/on-mainline-push.yml
+++ b/.github/workflows/on-mainline-push.yml
@@ -94,6 +94,8 @@ jobs:
           aws-region: us-east-1
       - name: Upload bundle to S3
         run: aws s3 sync public s3://cy7.io
+      - name: Upload bundle to eu-west-1 S3 mirror
+        run: aws s3 sync public s3://a.mirrors.cy7.io
       - name: Invalidate CloudFront caches
         run: aws cloudfront create-invalidation --distribution-id ${{ needs.query-existing-infrastructure.outputs.website-cloudfront-distribution-id }} --paths "/*"
   deploy-storybook:
@@ -116,3 +118,5 @@ jobs:
           aws-region: us-east-1
       - name: Upload bundle to S3
         run: aws s3 sync storybook-static s3://storybook.cy7.io
+      - name: Upload bundle to eu-west-1 S3 mirror
+        run: aws s3 sync public s3://a.mirrors.storybook.cy7.io

--- a/deploy/infra/main.tf
+++ b/deploy/infra/main.tf
@@ -2,6 +2,11 @@ provider "aws" {
   region = "us-east-1"
 }
 
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+}
+
 terraform {
   required_version = "~> 1.1.0"
 
@@ -35,6 +40,11 @@ data "aws_cloudformation_export" "redirect_lambda_arn" {
 module "website" {
   source = "./modules/static_site"
 
+  providers = {
+    aws         = aws
+    aws.ireland = aws.ireland
+  }
+
   alias_domains = ["www.cy7.io"]
   edge_lambdas = [
     {
@@ -52,6 +62,11 @@ module "website" {
 
 module "storybook" {
   source = "./modules/static_site"
+
+  providers = {
+    aws         = aws
+    aws.ireland = aws.ireland
+  }
 
   full_domain = "storybook.cy7.io"
   root_domain = local.root_domain

--- a/deploy/infra/modules/static_site/main.tf
+++ b/deploy/infra/modules/static_site/main.tf
@@ -1,3 +1,13 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "3.30"
+      configuration_aliases = [ aws.ireland ]
+    }
+  }
+}
+
 locals {
   s3_origin_id = "S3-${var.full_domain}"
   all_domains  = concat([var.full_domain], var.alias_domains)
@@ -51,6 +61,17 @@ resource "aws_cloudfront_origin_access_identity" "main" {
 resource "aws_s3_bucket" "root" {
   acl    = "private"
   bucket = var.full_domain
+
+  tags = {
+    project = "website"
+  }
+}
+
+resource "aws_s3_bucket" "mirror_a" {
+  provider = aws.ireland
+
+  acl    = "private"
+  bucket = "a.mirrors.${var.full_domain}"
 
   tags = {
     project = "website"


### PR DESCRIPTION
In preparation for migrating the CloudFront distributions to point to these buckets instead. 

Moving the buckets is an experiment to find out if a geographically nearby origin improves cold start loading times for UK traffic (which is the most likely location for users, because the only user is me (lol)).