### PR TITLE
Transfer over to new root bucket

### DIFF
--- a/deploy/infra/modules/static_site/main.tf
+++ b/deploy/infra/modules/static_site/main.tf
@@ -160,7 +160,7 @@ resource "aws_cloudfront_distribution" "web" {
   }
 
   origin {
-    domain_name = aws_s3_bucket.mirror_a.bucket_regional_domain_name
+    domain_name = aws_s3_bucket.root.bucket_regional_domain_name
     origin_id   = local.s3_origin_id
 
     s3_origin_config {

--- a/deploy/infra/modules/static_site/main.tf
+++ b/deploy/infra/modules/static_site/main.tf
@@ -27,7 +27,6 @@ data "aws_acm_certificate" "root" {
   domain = var.root_domain
 }
 
-# Policy granting the Origin Access Identity permission to read from the S3 root origin bucket.
 data "aws_iam_policy_document" "s3_root_policy" {
   statement {
     actions   = ["s3:GetObject"]
@@ -52,37 +51,6 @@ data "aws_iam_policy_document" "s3_root_policy" {
   }
 }
 
-# Policy granting the Origin Access Identity permission to read from the S3 mirror_a origin bucket.
-data "aws_iam_policy_document" "s3_mirror_a_policy" {
-  statement {
-    actions   = ["s3:GetObject"]
-    resources = [
-      "${aws_s3_bucket.mirror_a.arn}/*"
-    ]
-
-    principals {
-      type        = "AWS"
-      identifiers = [aws_cloudfront_origin_access_identity.main.iam_arn]
-    }
-  }
-
-  statement {
-    actions   = ["s3:ListBucket"]
-    resources = [aws_s3_bucket.mirror_a.arn]
-
-    principals {
-      type        = "AWS"
-      identifiers = [aws_cloudfront_origin_access_identity.main.iam_arn]
-    }
-  }
-}
-
-# A special type of user that allows us to expose the origin buckets only via CloudFront.
-# https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-s3.html
-resource "aws_cloudfront_origin_access_identity" "main" {
-  comment = var.full_domain
-}
-
 # The origin bucket that holds the static files for the website. Note the bucket is private: that's because the contents
 # are exposed via CloudFront only.
 resource "aws_s3_bucket" "root" {
@@ -96,25 +64,8 @@ resource "aws_s3_bucket" "root" {
   }
 }
 
-# TODO: remove this
-resource "aws_s3_bucket" "mirror_a" {
-  provider = aws.ireland
-
-  acl    = "private"
-  bucket = "a.mirrors.${var.full_domain}"
-
-  tags = {
-    project = "website"
-  }
-}
-
-# Applies the policy (see aws_iam_policy_document.s3_policy above) to the bucket, granting CloudFront read access to
-# the private origin bucket.
-resource "aws_s3_bucket_policy" "root" {
-  provider = aws.ireland
-
-  bucket = aws_s3_bucket.mirror_a.id
-  policy = data.aws_iam_policy_document.s3_mirror_a_policy.json
+resource "aws_cloudfront_origin_access_identity" "main" {
+  comment = var.full_domain
 }
 
 resource "aws_s3_bucket_policy" "new_root" {


### PR DESCRIPTION
This is the final step in a migration from `us-east-1` origin buckets to `eu-west-1` origin buckets.

Previously:

* Mirror buckets in `eu-west-1` were introduced (https://github.com/cycleseven/cy7.io/pull/8 and https://github.com/cycleseven/cy7.io/pull/9)
* CloudFront origin was switched over to the new `eu-west-1` mirrors, and original `us-east-1` buckets were removed (https://github.com/cycleseven/cy7.io/pull/10)

At this point, the migration was technically complete. But the new root buckets were still named as if they were mirrors. To restore the old root `cy7.io` / `storybook.cy7.io` names to the buckets...

* New replica buckets with those names were created in the new region `eu-west-1` (https://github.com/cycleseven/cy7.io/pull/11)
* Finally, this PR switches over to those new buckets with nice names and removes the mirror buckets.