### PR TITLE
Strip runtime JS from the bundle

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -147,5 +147,7 @@ module.exports = {
     // this (optional) plugin enables Progressive Web App + Offline functionality
     // To learn more, visit: https://gatsby.dev/offline
     // `gatsby-plugin-offline`,
+
+    "gatsby-plugin-no-javascript",
   ],
 };

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "gatsby-plugin-image": "1.13.0",
     "gatsby-plugin-manifest": "3.13.0",
     "gatsby-plugin-mdx": "2.13.0",
+    "gatsby-plugin-no-javascript": "2.0.5",
     "gatsby-plugin-offline": "4.13.0",
     "gatsby-plugin-react-helmet": "4.13.0",
     "gatsby-plugin-sharp": "3.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7216,20 +7216,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000989, caniuse-lite@^1.0.30001093, caniuse-lite@^1.0.30001173, caniuse-lite@^1.0.30001181:
-  version "1.0.30001247"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001247.tgz"
-  integrity sha512-4rS7co+7+AoOSPRPOPUt5/GdaqZc0EsUpWk66ofE3HJTAajUK2Ss2VwoNzVN69ghg8lYYlh0an0Iy4LIHHo9UQ==
-
-caniuse-lite@^1.0.30001109:
-  version "1.0.30001252"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001252.tgz#cb16e4e3dafe948fc4a9bb3307aea054b912019a"
-  integrity sha512-I56jhWDGMtdILQORdusxBOH+Nl/KgQSdDmpJezYddnAkVOmnoU8zwjTV9xAjMIYxr0iPreEAVylCGcmHCjfaOw==
-
-caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001248, caniuse-lite@^1.0.30001251:
-  version "1.0.30001251"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz#6853a606ec50893115db660f82c094d18f096d85"
-  integrity sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000989, caniuse-lite@^1.0.30001093, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001173, caniuse-lite@^1.0.30001181, caniuse-lite@^1.0.30001248, caniuse-lite@^1.0.30001251:
+  version "1.0.30001342"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001342.tgz"
+  integrity sha512-bn6sOCu7L7jcbBbyNhLg0qzXdJ/PMbybZTH/BA6Roet9wxYRm6Tr9D0s0uhLkOZ6MSG+QU6txUgdpr3MXIVqjA==
 
 capital-case@^1.0.4:
   version "1.0.4"
@@ -10835,6 +10825,11 @@ gatsby-plugin-mdx@2.13.0:
     unist-util-map "^1.0.5"
     unist-util-remove "^1.0.3"
     unist-util-visit "^1.4.1"
+
+gatsby-plugin-no-javascript@2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-no-javascript/-/gatsby-plugin-no-javascript-2.0.5.tgz#b30bd412fabeab1663b6c40a3aaeee878acfddea"
+  integrity sha512-AV8THLpxFH0lOAYxO2bTkyqucp4KxjbF07GSMNnCpmgWp+G88YGhsuWH/Jc+cjoNZl+01MXvMTsmawBWNypxeA==
 
 gatsby-plugin-offline@4.13.0:
   version "4.13.0"


### PR DESCRIPTION
Runtime JS does a couple of things on my site (and on Gatsby sites in general)...

- Links use client-side routing (ie. a JS chunk is fetched, DOM is dynamically updated to build the new page, rather than fetching HTML)
- Images can be lazy loaded in fancy ways (but I'm not using that right now)

For me, build-time JS is enough for now. I'm happy to have regular links (in fact, I prefer having native browser loading feedback). I don't have any custom dynamic behaviour (eg. stateful React components etc). While HTML + CSS are rendered via JS, that's all done at build time already.

Let's experiment with no JS 🙀 