### PR TITLE
Upgrade to latest minor version of Node.js v16

### DIFF
--- a/.github/workflows/check-frontend-code-quality.yml
+++ b/.github/workflows/check-frontend-code-quality.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 16.7.0
+          node-version: 16.18.0
       - name: Download generated GraphQL types
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/on-branch-push.yml
+++ b/.github/workflows/on-branch-push.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 16.7.0
+          node-version: 16.18.0
       - uses: ./.github/actions/yarn-install
       - run: yarn build
       - name: Store generated code
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 16.7.0
+          node-version: 16.18.0
       - uses: ./.github/actions/yarn-install
       - run: yarn build-storybook --docs --quiet
   check-frontend-code-quality:

--- a/.github/workflows/on-mainline-push.yml
+++ b/.github/workflows/on-mainline-push.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 16.7.0
+          node-version: 16.18.0
       - uses: ./.github/actions/yarn-install
       - run: yarn build
       - name: Store generated code
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 16.7.0
+          node-version: 16.18.0
       - uses: ./.github/actions/yarn-install
       - run: yarn build-storybook --docs --quiet
       - name: Store Storybook build output

--- a/README.md
+++ b/README.md
@@ -4,33 +4,29 @@ Source code for [cy7.io](https://cy7.io), built with Gatsby.
 
 ## Getting started with local development
 
-This project is built with JavaScript, so you'll need a healthy Node environment on your machine before starting.
+System requirements for running this project locally are:
 
-The recommended package manager is [Yarn v1](https://classic.yarnpkg.com/lang/en/). These instructions are written with Yarn in mind. But in theory, the equivalent `npm` commands should work just fine if that's your preference.
+- Node.js v16
+- Yarn v1
+- Terraform v1
 
-1. **Check the `engines` field of `package.json` for the required versions of Node and Yarn.** Make sure you have those installed. Check with the following commands if you like:
+1. **Check the `engines` field of `package.json` for the required versions of Node and Yarn.** Make sure you have those installed.
+
+   You can check with the following commands:
 
    ```
    $ node --version
-   v16.7.0
+   v16.18.0
 
    $ yarn --version
-   1.22.5
+   1.22.19
    ```
-
-   **Or, simply attempt step 2.** Yarn will exit with a error if your Node version isn't supported.
-
-   > **Tip:** use the [`n` command line tool](https://github.com/tj/n) to manage your different Node versions for easier switching when changing projects.
 
 2. **Install dependencies.**
 
    ```bash
    yarn
    ```
-
-   Your `node_modules` will be populated with all third-party code required for this project.
-
-   During this step, Git hooks will be installed behind-the-scenes to perform code quality checks on `git commit` and `git push`. Check out the Code Quality section in the [developer guide](https://storybook.cy7.io/) for more info.
 
 3. **That's it!** Happy developing. You can start an instance of Gatsby's [development server](https://www.gatsbyjs.com/docs/tutorial/part-1/#run-your-site-locally) like this:
 
@@ -52,17 +48,17 @@ The Terraform config that defines the infrastructure for the website is part of 
 
 That means that for now, in practice, Terraform is also a requirement for developing on the project. Grab a copy of the `required_version` specified in `deploy/infra/main.tf` from [Terraform's download page](https://www.terraform.io/downloads.html).
 
-> **TODO:** provide better support for devs without `terraform` on their machine, or with different versions. Terraform code formatting checks aren't really required for pure frontend work.
+> **TODO:** provide better support for devs without `terraform` on their machine, or with different versions. Terraform code formatting checks shouldn't be required for frontend work.
 
 ## Git hooks
 
 To improve code quality, automated checks take place when committing and pushing code via `git commit` and `git push`, using [Git hooks](https://www.atlassian.com/git/tutorials/git-hooks). These are set up for you behind-the-scenes when installing dependencies with `yarn` by [Lefthook](https://github.com/evilmartians/lefthook).
 
-You can read more about this project's code quality policy in the developer guide.
+You can read more about this project's code quality guidance in the [developer guide](https://storybook.cy7.io/?path=/docs/guides-code-quality--page).
 
 ## Other useful commands
 
-- **Build a production bundle:** `yarn gatsby build` (or `yarn build`)
+- **Build a production bundle:** `yarn gatsby build` (or just `yarn build`)
 - **Serve that built production bundle locally:** `yarn gatsby serve`
 - **Run Jest test suite:** `yarn jest` (or `yarn test`)
 - **Check for ESLint violations:** `yarn eslint src`


### PR DESCRIPTION
* Update GitHub Actions workflows to use the latest minor version of Node.js v16
* Tidy up the README
  * Git hooks only need to be explained once 😅 
  * General JS knowledge shouldn't need to be explained at all
  * Discourage `npm` usage by not mentioning it